### PR TITLE
Update docs to use new action repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This GitHub Action allows you to run [Claude Code](https://www.anthropic.com/claude-code) within your GitHub Actions workflows. You can use this to build any custom workflow on top of Claude Code.
 
-For simply tagging @claude in issues and PRs out of the box, [check out the Claude Code action and GitHub app](https://github.com/anthropics/claude-code-action).
+For simply tagging @claude in issues and PRs out of the box, [check out the Claude Code action and GitHub app](https://github.com/RishuKayatani/claude-code-action).
 
 ## Usage
 
@@ -11,7 +11,7 @@ Add the following to your workflow file:
 ```yaml
 # Using a direct prompt
 - name: Run Claude Code with direct prompt
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
@@ -19,7 +19,7 @@ Add the following to your workflow file:
 
 # Or using a prompt from a file
 - name: Run Claude Code with prompt file
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt_file: "/path/to/prompt.txt"
     allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
@@ -27,7 +27,7 @@ Add the following to your workflow file:
 
 # Or limiting the conversation turns
 - name: Run Claude Code with limited turns
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
@@ -68,7 +68,7 @@ You can provide a custom MCP configuration file to dynamically load MCP servers:
 
 ```yaml
 - name: Run Claude Code with MCP config
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     mcp_config: "path/to/mcp-config.json"
@@ -97,7 +97,7 @@ You can combine MCP config with other inputs like allowed tools:
 ```yaml
 # Using multiple inputs together
 - name: Run Claude Code with MCP and custom tools
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Access the custom MCP server and use its tools"
     mcp_config: "mcp-config.json"
@@ -126,7 +126,7 @@ jobs:
 
       - name: Run Code Review with Claude
         id: code-review
-        uses: anthropics/claude-code-base-action@beta
+        uses: RishuKayatani/claude-code-base-action@beta
         with:
           prompt: "Review the PR changes. Focus on code quality, potential bugs, and performance issues. Suggest improvements where appropriate. Write your review as markdown text."
           allowed_tools: "Bash(git diff --name-only HEAD~1),Bash(git diff HEAD~1),View,GlobTool,GrepTool,Write"
@@ -189,7 +189,7 @@ Use provider-specific model names based on your chosen provider:
 ```yaml
 # For direct Anthropic API (default)
 - name: Run Claude Code with Anthropic API
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     model: "claude-3-7-sonnet-20250219"
@@ -203,7 +203,7 @@ Use provider-specific model names based on your chosen provider:
     aws-region: us-west-2
 
 - name: Run Claude Code with Bedrock
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     model: "anthropic.claude-3-7-sonnet-20250219-v1:0"
@@ -217,7 +217,7 @@ Use provider-specific model names based on your chosen provider:
     service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
 - name: Run Claude Code with Vertex AI
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     model: "claude-3-7-sonnet@20250219"
@@ -236,7 +236,7 @@ This example shows how to use OIDC authentication with AWS Bedrock:
     aws-region: us-west-2
 
 - name: Run Claude Code with AWS OIDC
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     use_bedrock: "true"
@@ -256,7 +256,7 @@ This example shows how to use OIDC authentication with GCP Vertex AI:
     service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
 - name: Run Claude Code with GCP OIDC
-  uses: anthropics/claude-code-base-action@beta
+  uses: RishuKayatani/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
     use_vertex: "true"

--- a/examples/issue-triage.yml
+++ b/examples/issue-triage.yml
@@ -95,7 +95,7 @@ jobs:
           EOF
 
       - name: Run Claude Code for Issue Triage
-        uses: anthropics/claude-code-base-action@beta
+        uses: RishuKayatani/claude-code-base-action@beta
         with:
           prompt_file: /tmp/claude-prompts/triage-prompt.txt
           allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"


### PR DESCRIPTION
## Summary
- update README link to claude code action
- switch usage examples to reference `RishuKayatani` instead of `anthropics`
- update example workflow with new action reference

## Testing
- `bun test` *(fails: Cannot find module '@actions/core')*